### PR TITLE
Add Puppet 8 support. Drop near EOL Linux version support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.3'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Run static validations
@@ -66,7 +66,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.3'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Provision Testing Environments

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Build and Deploy

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 4.13.1 < 10.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -21,34 +21,22 @@
       ]
     },
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "8"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
+        "12",
         "11"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "8",
-        "7"
+        "8"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
       ]
     },
     {
@@ -62,7 +50,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ],
   "tags": [

--- a/provision.yaml
+++ b/provision.yaml
@@ -3,9 +3,7 @@ default:
   provisioner: docker
   images:
     - 'litmusimage/almalinux:8'
-    - 'litmusimage/centos:8'
     - 'litmusimage/debian:11'
     - 'litmusimage/rockylinux:8'
-    - 'litmusimage/scientificlinux:7'
     - 'litmusimage/ubuntu:22.04'
     - 'litmusimage/ubuntu:20.04'


### PR DESCRIPTION
- Add Puppet 8 support
- Drop Puppet 6 support
- Add Debian 12 support
- Drop CentOS support
- Drop ScientifixLinux support
- Drop RedHat 7 support